### PR TITLE
Fix issue with hyphen in header

### DIFF
--- a/kong/plugins/host-interpolate-by-header/handler.lua
+++ b/kong/plugins/host-interpolate-by-header/handler.lua
@@ -10,11 +10,13 @@ local function interpolate_header(host, _header, header_val, conf)
     value = tonumber(value) % conf.modulo_by
   end
 
+  _header = _header:gsub("%-","%%%-")
   host = host:gsub("<" .. _header .. ">", tostring(value))
   return host
 end
 
 local function interpolate_env_variable(host, env, env_val)
+  env = env:gsub("%-","%%%-")
   host = host:gsub("<" .. env .. ">", tostring(env_val))
   return host
 end
@@ -61,7 +63,7 @@ function HostInterpolateByHeaderHandler:access(conf)
   end
 
   kong.log.debug("Final value of hostname is: " .. host)
-  kong.service.set_target(host, tonumber(80))
+  kong.service.set_target(host, tonumber(conf.port))
   kong.ctx.shared.upstream_host = host
 end
 

--- a/kong/plugins/host-interpolate-by-header/schema.lua
+++ b/kong/plugins/host-interpolate-by-header/schema.lua
@@ -40,6 +40,12 @@ return {
             }
           },
           {
+            port = typedefs.port{
+              default = 80
+            }
+          },
+
+          {
             operation = {
               type = "string",
               len_min = 0,

--- a/spec/host-interpolate-by-header/run_spec.lua
+++ b/spec/host-interpolate-by-header/run_spec.lua
@@ -120,7 +120,7 @@ for _, strategy in helpers.each_strategy() do
       )
 
       describe(
-        "\n ** Request should go to fallback host when no such header is present",
+        "\n ** Request should go to fallback host when no placeholder header is present ",
         function()
 
           it(
@@ -180,7 +180,7 @@ for _, strategy in helpers.each_strategy() do
       )
 
       describe(
-        "\n ** Request to upstream should be sent to fallback hostname when any of the header is missing",
+        "\n ** Request to upstream should be sent to fallback hostname when any of the headers is missing",
         function()
           it(
             "\nStatus code should be 200 and host should be fallback_host",
@@ -213,15 +213,16 @@ for _, strategy in helpers.each_strategy() do
         "\n ** Request to upstream should be sent to correct hostname as per modulo logic",
         function()
           setup(function()
-          local plugin = "host-interpolate-by-header"
-          local host = "service_shard_<user_id>.com"
-          local fallback_host = ""
-          local operation = "modulo"
-          local modulo_by = 3
-          local headers = {"user_id"}
+            local plugin = "host-interpolate-by-header"
+            local host = "service_shard_<user_id>.com"
+            local fallback_host = ""
+            local operation = "modulo"
+            local modulo_by = 3
+            local headers = {"user_id"}
 
-          update_config(plugin, host, fallback_host, operation, modulo_by, headers)
+            update_config(plugin, host, fallback_host, operation, modulo_by, headers)
           end)
+
           it(
             "\nCheck status code and host in response header",
             function()
@@ -262,6 +263,7 @@ for _, strategy in helpers.each_strategy() do
 
             update_config(plugin, host, fallback_host, operation, modulo_by, headers)
           end)
+
           it(
             "\nStatus code should be 422",
             function()
@@ -298,8 +300,10 @@ for _, strategy in helpers.each_strategy() do
             local modulo_by = 1
             local headers = {host_placeholder}
             local port = 10000
+
             update_config(plugin, host, fallback_host, operation, modulo_by, headers, port)
           end)
+
           it(
             "\nStatus code should be 502",
             function()
@@ -332,8 +336,10 @@ for _, strategy in helpers.each_strategy() do
             local modulo_by = 1
             local headers = {host_placeholder}
             local port = SERVER_PORT
+
             update_config(plugin, host, fallback_host, operation, modulo_by, headers, port)
           end)
+
           it(
             "\nStatus code should be 200",
             function()

--- a/spec/host-interpolate-by-header/run_spec.lua
+++ b/spec/host-interpolate-by-header/run_spec.lua
@@ -251,7 +251,7 @@ for _, strategy in helpers.each_strategy() do
       )
 
       describe(
-        "\n ** Request to upstream should fail with error code 422",
+        "\n ** Request to upstream should fail with error code 422 if placeholder header and fallback host is absent",
         function()
           setup(function()
             local plugin = "host-interpolate-by-header"
@@ -362,7 +362,7 @@ for _, strategy in helpers.each_strategy() do
       )
 
       describe(
-        "\n ** Should replace place_holder with a hyphen in the host",
+        "\n ** Should successfully replace place_holder containing a hyphen in the host",
         function()
           setup(function()
             local plugin = "host-interpolate-by-header"


### PR DESCRIPTION
# Summary
Fixed issue with hyphen in Placeholder in host.

### Issue Description
The plugin's handler.lua used gsub method to replace placeholder in host with corresponding header value. 
gsub does pattern matching and '-' is a special character. '-' matches with 0 or more occurrences of previous character class ([Link](https://www.lua.org/pil/20.2.html)).
Solution: added escape character(%) before '-' wherever it occurs in host.

### Full changelog

* Added a line to replace '-' with '%-' in host
* Removed port which was hardcoded in handler.lua and added is a value in config with default value 80
* Added test cases for both the fixes

### Issues resolved

Fix #49 